### PR TITLE
Extension unscoped option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 pkg
 .rvmrc
 Gemfile.lock
+.idea

--- a/lib/unscoped_associations.rb
+++ b/lib/unscoped_associations.rb
@@ -45,7 +45,7 @@ module UnscopedAssociations
     end
 
     def unscoped_option_to_class_name(option)
-      case option.class
+      case option
         when String
           option.camelize
         when Symbol

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -41,6 +41,7 @@ class Vote < ActiveRecord::Base
   has_one :str_user, through: :comment, unscoped: 'comment', source: :user
   has_one :sym_user, through: :comment, unscoped: :comment, source: :user
   has_one :class_user, through: :comment, unscoped: Comment, source: :user
+  has_one :arr_user, through: :comment, unscoped: [:comment, User], source: :user
 
   default_scope { where(public: true) }
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -35,6 +35,12 @@ end
 
 class Vote < ActiveRecord::Base
   belongs_to :votable, polymorphic: true, unscoped: true
+  # @note dirty hack for creating through-association
+  belongs_to :comment, foreign_key: 'votable_id', class_name: 'Comment'
+  has_one :bool_user, through: :comment, unscoped: true, source: :user
+  has_one :str_user, through: :comment, unscoped: 'comment', source: :user
+  has_one :sym_user, through: :comment, unscoped: :comment, source: :user
+  has_one :class_user, through: :comment, unscoped: Comment, source: :user
 
   default_scope { where(public: true) }
 end

--- a/spec/unscoped_associations_spec.rb
+++ b/spec/unscoped_associations_spec.rb
@@ -1,58 +1,85 @@
 require 'spec_helper'
 
 describe UnscopedAssociations do
-  let!(:user) { User.create(active: false) }
-  let!(:comment) { Comment.create(user_id: user.id, public: false) }
-  let!(:user_vote) { user.votes.create(public: false) }
-  let!(:comment_vote) { comment.votes.create }
+  describe '(without through association)' do
+    let!(:user) { User.create(active: false) }
+    let!(:comment) { Comment.create(user_id: user.id, public: false) }
+    let!(:user_vote) { user.votes.create(public: false) }
+    let!(:comment_vote) { comment.votes.create }
 
-  context 'a belongs to association' do
-    it 'scoped' do
-      expect(comment.user).to be_nil
-      expect(comment.scoped_user).to be_nil
+    context 'a belongs to association' do
+      it 'scoped' do
+        expect(comment.user).to be_nil
+        expect(comment.scoped_user).to be_nil
+      end
+
+      it 'unscoped' do
+        expect(comment.unscoped_user).to eq(user)
+      end
+
+      it 'unscoped polymorphic' do
+        expect(comment_vote.votable).to eq(comment)
+      end
     end
 
-    it 'unscoped' do
-      expect(comment.unscoped_user).to eq(user)
+    context 'a has one association' do
+      it 'scoped' do
+        expect(user.last_comment).to be_nil
+      end
+
+      it 'unscoped' do
+        expect(user.unscoped_last_comment).to eq(comment)
+      end
     end
 
-    it 'unscoped polymorphic' do
-      expect(comment_vote.votable).to eq(comment)
+    context 'a has many association' do
+      it 'scoped' do
+        expect(user.comments).to be_empty
+      end
+
+      it 'scoped with an extension' do
+        expect(user.comments.today).to be_empty
+      end
+
+      it 'unscoped' do
+        expect(user.unscoped_comments).to eq([comment])
+      end
+
+      it 'unscoped with an extension' do
+        # Extended methods take the default_scope
+        expect(user.unscoped_comments.today).to be_empty
+        # Ideally, it should skip the default_scope
+        # expect(user.unscoped_comments.today).to eq([comment])
+      end
+
+      it 'unscoped polymorphic' do
+        expect(user.votes).to eq([user_vote])
+      end
     end
   end
 
-  context 'a has one association' do
-    it 'scoped' do
-      expect(user.last_comment).to be_nil
-    end
+  describe '(with through association)' do
+    let!(:user) { User.create(active: true) }
+    let!(:comment) { Comment.create(user_id: user.id, public: false) }
+    let!(:comment_vote) { comment.votes.create(public: true) }
 
-    it 'unscoped' do
-      expect(user.unscoped_last_comment).to eq(comment)
+    context 'a through association' do
+      it 'have unscoped option eql boolean' do
+        expect(comment_vote.bool_user).to be_nil
+      end
+
+      it 'have unscoped option eql Symbol' do
+        expect(comment_vote.sym_user).to eql(user)
+      end
+
+      it 'have unscoped option eql String' do
+        expect(comment_vote.str_user).to eql(user)
+      end
+
+      it 'have unscoped option eql Class' do
+        expect(comment_vote.class_user).to eql(user)
+      end
     end
   end
 
-  context 'a has many association' do
-    it 'scoped' do
-      expect(user.comments).to be_empty
-    end
-
-    it 'scoped with an extension' do
-      expect(user.comments.today).to be_empty
-    end
-
-    it 'unscoped' do
-      expect(user.unscoped_comments).to eq([comment])
-    end
-
-    it 'unscoped with an extension' do
-      # Extended methods take the default_scope
-      expect(user.unscoped_comments.today).to be_empty
-      # Ideally, it should skip the default_scope
-      # expect(user.unscoped_comments.today).to eq([comment])
-    end
-
-    it 'unscoped polymorphic' do
-      expect(user.votes).to eq([user_vote])
-    end
-  end
 end


### PR DESCRIPTION
# before

belongs_to :product, unscoped: true # ok
has_one :project, through: :product, unscoped: true # unscoped don't work
has_many :members, through: :project # unscoped don't work, too
# after

belongs_to :product, unscoped: true # ok
has_one :project, through: :product, uncoped: :product # ok
has_many :members, through: :project, uncoped: [:product, Project] # ok
