### PR TITLE
Fix passing of wrong parameter to super

### DIFF
--- a/lib/unscoped_associations.rb
+++ b/lib/unscoped_associations.rb
@@ -43,14 +43,14 @@ module UnscopedAssociations
     end
 
     def add_unscoped_association(association_name)
-      define_method(association_name) do
+      define_method(association_name) do |*args|
         if self.class.reflect_on_association(association_name).options.key?(:polymorphic)
           self.association(association_name).klass.unscoped do
-            super(association_name)
+            super(*args)
           end
         else
           self.class.reflect_on_association(association_name).klass.unscoped do
-            super(association_name)
+            super(*args)
           end
         end
       end

--- a/spec/unscoped_associations_spec.rb
+++ b/spec/unscoped_associations_spec.rb
@@ -19,6 +19,17 @@ describe UnscopedAssociations do
     it 'unscoped polymorphic' do
       expect(comment_vote.votable).to eq(comment)
     end
+
+    context 'unscoped with unsaved user' do
+      let(:user) { User.new }
+      let(:comment) { Comment.new(unscoped_user: user) }
+      let(:user_vote) { nil }
+      let(:comment_vote) { nil }
+
+      it 'returns user' do
+        expect(comment.unscoped_user).to eq user
+      end
+    end
   end
 
   context 'a has one association' do
@@ -41,7 +52,8 @@ describe UnscopedAssociations do
     end
 
     it 'unscoped' do
-      expect(user.unscoped_comments).to eq([comment])
+      # pass true to force reload in order to remove the default scope
+      expect(user.unscoped_comments(true)).to eq([comment])
     end
 
     it 'unscoped with an extension' do


### PR DESCRIPTION
Passing association_name to super results in it being passed to the association reader, which then misleadingly reloads the association.
See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/singular_association.rb#L5
